### PR TITLE
Add PHPUnit test for expired budgets

### DIFF
--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit colors="true">
+    <testsuites>
+        <testsuite name="Application Test Suite">
+            <directory suffix="Test.php">tests</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/OrcamentoTest.php
+++ b/tests/OrcamentoTest.php
@@ -1,0 +1,48 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../app/Models/Orcamento.php';
+
+class OrcamentoTest extends TestCase
+{
+    private $pdo;
+
+    protected function setUp(): void
+    {
+        global $pdo;
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $this->pdo->sqliteCreateFunction('CURDATE', function() {
+            return date('Y-m-d');
+        });
+        $pdo = $this->pdo;
+        $this->pdo->exec("CREATE TABLE orcamentos (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            cliente_nome TEXT,
+            cliente_contato TEXT,
+            data TEXT,
+            validade TEXT,
+            observacoes TEXT,
+            total REAL
+        )");
+    }
+
+    public function testExcluirExpiradosRemovesPastRecords()
+    {
+        global $pdo;
+        $pastDate = date('Y-m-d', strtotime('-1 day'));
+        $futureDate = date('Y-m-d', strtotime('+1 day'));
+
+        $stmt = $this->pdo->prepare("INSERT INTO orcamentos (cliente_nome, cliente_contato, data, validade, observacoes, total) VALUES (?, ?, ?, ?, ?, ?)");
+        $stmt->execute(['Past', 'cont', $pastDate, $pastDate, 'obs', 10]);
+        $stmt->execute(['Future', 'cont', $futureDate, $futureDate, 'obs', 20]);
+
+        Orcamento::excluirExpirados();
+
+        $remaining = $this->pdo->query("SELECT COUNT(*) FROM orcamentos")->fetchColumn();
+        $this->assertEquals(1, $remaining);
+
+        $validDate = $this->pdo->query("SELECT validade FROM orcamentos")->fetchColumn();
+        $this->assertEquals($futureDate, $validDate);
+    }
+}


### PR DESCRIPTION
## Summary
- add PHPUnit config
- add test coverage for `Orcamento::excluirExpirados` using in-memory SQLite

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68663b6348f8832fad0740d6a956830d