### PR TITLE
Fix redirect path handling

### DIFF
--- a/app/Config/config.php
+++ b/app/Config/config.php
@@ -22,6 +22,12 @@ try {
 
 // Função simples para redirecionar
 function redirect($url) {
+    // Prefix base path when a relative path is provided
+    if (!preg_match('#^https?://#', $url)) {
+        if (strpos($url, BASE_URL) !== 0) {
+            $url = rtrim(BASE_URL, '/') . '/' . ltrim($url, '/');
+        }
+    }
     header("Location: $url");
     exit;
 }


### PR DESCRIPTION
## Summary
- fix redirect helper to prefix BASE_URL for internal routes

## Testing
- `php -l app/Models/Cliente.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68663a43d4ac832f81c526b334b7d0b2