### PR TITLE
Fix Router comment line break

### DIFF
--- a/app/Core/Router.php
+++ b/app/Core/Router.php
@@ -2,4 +2,4 @@
 // app/Core/Router.php
 
 // Este arquivo pode ficar vazio, pois o roteamento já é feito no index.php
-// ou, se desejar centralizar o roteamento, mova a lógica de index.php pra cá futuramente.
+// Ou, se desejar centralizar o roteamento, mova a lógica de index.php pra cá futuramente.


### PR DESCRIPTION
## Summary
- adjust Router comment to keep `futuramente` on one line

## Testing
- `php -l app/Core/Router.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68663b5ee08c832fba4c2b646d6ca23e