### PR TITLE
Add Cliente model tests and fix update query

### DIFF
--- a/app/Models/Cliente.php
+++ b/app/Models/Cliente.php
@@ -37,10 +37,8 @@ class Cliente {
 
     public static function atualizar($id, $dados) {
         global $pdo;
-        $stmt = $pdo->prepare("
-            UPDATE clientes SET nome = ?, telefone = ?, email = ?, cpf_cnpj = ?, tipo = ?, contato = ?, responsavel = ?, insc_municipal = ?, insc_estadual = ?, observacoes = ?
-            WHERE id = ?
-        ");
+        $stmt = $pdo->prepare("UPDATE clientes SET nome = ?, telefone = ?, email = ?, cpf_cnpj = ?, tipo = ?, contato = ?, responsavel = ?, insc_municipal = ?, insc_estadual = ?, observacoes = ?
+            WHERE id = ?");
         $stmt->execute([
             $dados['nome'], $dados['telefone'], $dados['email'],
             $dados['cpf_cnpj'], $dados['tipo'], $dados['contato'] ?? null,

--- a/tests/ClienteTest.php
+++ b/tests/ClienteTest.php
@@ -1,0 +1,63 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../app/Models/Cliente.php';
+
+class ClienteTest extends TestCase
+{
+    private $pdo;
+
+    protected function setUp(): void
+    {
+        global $pdo;
+        $this->pdo = new PDO('sqlite::memory:');
+        $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+        $pdo = $this->pdo;
+        $this->pdo->exec("CREATE TABLE clientes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            nome TEXT,
+            telefone TEXT,
+            email TEXT,
+            cpf_cnpj TEXT,
+            tipo TEXT,
+            contato TEXT,
+            responsavel TEXT,
+            insc_municipal TEXT,
+            insc_estadual TEXT,
+            observacoes TEXT
+        )");
+    }
+
+    public function testSalvarEAtualizar()
+    {
+        global $pdo;
+        $dados = [
+            'nome' => 'Joao',
+            'telefone' => '123',
+            'email' => 'j@example.com',
+            'cpf_cnpj' => '111',
+            'tipo' => 'F',
+            'contato' => null,
+            'responsavel' => null,
+            'insc_municipal' => null,
+            'insc_estadual' => null,
+            'observacoes' => null
+        ];
+
+        Cliente::salvar($dados);
+
+        $id = $this->pdo->query('SELECT id FROM clientes')->fetchColumn();
+        $this->assertNotEmpty($id);
+
+        $nome = $this->pdo->query('SELECT nome FROM clientes WHERE id = ' . $id)->fetchColumn();
+        $this->assertEquals('Joao', $nome);
+
+        $dadosAtualizados = $dados;
+        $dadosAtualizados['nome'] = 'Maria';
+
+        Cliente::atualizar($id, $dadosAtualizados);
+
+        $novoNome = $this->pdo->query('SELECT nome FROM clientes WHERE id = ' . $id)->fetchColumn();
+        $this->assertEquals('Maria', $novoNome);
+    }
+}


### PR DESCRIPTION
## Summary
- fix SQL syntax in `Cliente::atualizar`
- add PHPUnit tests for `Cliente` model

## Testing
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68663f61f8d8832f8a74c8860e3f41cf